### PR TITLE
converters the probs into np array if its already not

### DIFF
--- a/xai/__init__.py
+++ b/xai/__init__.py
@@ -1035,14 +1035,14 @@ def _group_metrics(
 
 def smile_imbalance(
         y_test, 
-        probs, 
+        probs: np.ndarray, 
         threshold=0.5, 
         manual_review=None,
         display_breakdown=False,
         bins=10):
     
     # TODO: Change function so it only iterates once
-
+    probs = np.array(probs)
     preds = convert_probs(probs, threshold).flatten()
     d = pd.DataFrame(probs)
     d.columns = ["probs"]


### PR DESCRIPTION
`smile_imbalance()` funciton argument "probs" does not specify that it is required to be numpy array, but it does so i have added that data type in the argument letting the user know if he/she is to refer to the docs and i have also added a line `np.array()` which is an idempotent operation(if the array passed is already numpy array then it does nothing but if its not it changes the list into numpy array)


**Suggestion**
- If possible can you guys consider adding "save_plot_path" method to each function, so that when this package is used in production (which i am and people considering Continuous model delivery would use) all these plots could be saved to a particular directory for data scientists to look at later since in production, code would be used in scripts running on EC2 or other cloud servers and not on jupyter notebooks 
- My use case is I am retraining the model every week and XAI allows me to generate a evaluation report allowing me to remotely decide weather to push this weeks mode into  production 
- I considered adding it myself but i was not sure if this is the direction you guys wanted to take

Thank you
